### PR TITLE
Create a symlink to mysql-connector inside /lib

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,6 +177,11 @@ class gerrit (
       $mysql_java_package:
         ensure  => installed,
         require => Exec ['install_gerrit'],
+    } ->
+    file {
+      "${target}/lib/mysql-connector-java.jar" :
+        ensure => link,
+        target => $mysql_java_connector,
     }
   }
 


### PR DESCRIPTION
Create a link to `mysql-connector-java.jar` into `${target}/lib` to avoid `Cannot find com.mysql.jdbc.Driver`
