### PR TITLE
Add a folder define to add gerrit extra folders

### DIFF
--- a/manifests/folder.pp
+++ b/manifests/folder.pp
@@ -1,0 +1,14 @@
+define gerrit::folder(
+  $ensure   = 'directory',
+){
+
+  file{
+    "${gerrit::target}/${name}":
+      ensure   => $ensure,
+      owner    => $gerrit::user,
+      group    => $gerrit::user,
+      mode     => '0755',
+      require  => Exec['install_gerrit'],
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,6 +121,9 @@
 # [*user*]
 #   the user used to install gerrit
 #
+# [*extra_folders*]
+#   Extra folder to create on gerrit home directory
+#
 # === Examples
 #
 #  class {
@@ -239,6 +242,8 @@ class gerrit (
         require   => Exec ['install_gerrit'],
     }
   }
+
+  gerrit::folder { $extra_folders : }
 
   Gerrit::Config {
     file    => "${target}/etc/gerrit.config",


### PR DESCRIPTION
At installation time, gerrit creates a set of few folders.
It can uses more than the one created (ie. hooks, plugins, etc...).
This commits allow one to specify those folders.
