### PR TITLE
Add support for multi-valued config items

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -5,4 +5,4 @@ license 'MIT'
 summary 'Web based code review and project management for Git based projects. '
 description 'Gerrit is a web based code review system, facilitating online code reviews for projects using the Git version control system.'
 project_page 'https://code.google.com/p/gerrit/'
-
+dependency 'puppetlabs/stdlib', >= '4.0.0'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,16 +4,49 @@ define gerrit::config(
   $file   = "${gerrit::target}/etc/gerrit.config"
 ){
 
-  exec {
-    "config_$name":
-      command => "git config -f ${file} \"${name}\" \"${value}\"",
-      unless  => "git config -f ${file} \"${name}\"|grep -x \"${value}\"",
+  if type($value) == 'array' {
+    # Check if the existing value in the config is set to exactly the right
+    # combination of characters.  We do this by using a gross perl one-liner to
+    # compare stdout from git-config with what puppet thinks should be the
+    # output.  If it's not set to that, then we clear the value and notify the
+    # Exec below to set all the values in one shot.  We allow an exit code of 5
+    # from this check, since that just means that the value was already unset
+    # and we can't make it more empty.
+    $expected_output = join($value, '\n')
+    $compare = "perl -e '\$/=1; \$x=<STDIN>; exit(\$x eq \"${expected_output}\\n\" ? 0 : 1)'"
+    exec { "config_${name}_empty":
+      command => "git config -f ${file} --unset-all \"${name}\"",
+      unless  => "git config -f ${file} --get-all \"${name}\" | ${compare}",
       path    => $::path,
       require => Exec['install_gerrit'],
+      returns => [0, 5],
+    }
+
+    # We want to run all these commands together because we can't use puppet
+    # require to enforce ordering and the check on the empty exec assumes that
+    # the values are in a specific order.
+    $command = "git config -f ${file} --add \"${name}\" "
+    $set_commands = prefix($value, $command)
+    $all_commands = join($set_commands, '; ')
+    exec { "config_${name}":
+      command     => $all_commands,
+      path        => $::path,
+      refreshonly => true,
+      subscribe   => Exec["config_${name}_empty"],
+    }
+  } else {
+    exec {
+      "config_${name}":
+        command => "git config -f ${file} \"${name}\" \"${value}\"",
+        unless  => "git config -f ${file} \"${name}\"|grep -x \"${value}\"",
+        path    => $::path,
+        require => Exec['install_gerrit'],
+    }
+
   }
 
   if $gerrit::manage_service {
-    Exec["config_$name"] ~> Exec['reload_gerrit']
+    Exec["config_${name}"] ~> Exec['reload_gerrit']
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -186,7 +186,7 @@ class gerrit (
   $database_name            = 'db/ReviewDB',
   $database_password        = undef,
   $database_username        = undef,
-  $download_scheme          = 'ssh anon_http http',
+  $download_scheme          = ['ssh', 'anon_http', 'http'],
   $git_package              = $gerrit::params::git_package,
   $gitweb_cgi_path          = $gerrit::params::gitweb_cgi_path,
   $gitweb_package           = $gerrit::params::gitweb_package,


### PR DESCRIPTION
This handles array valued config items specially to insure that the
git-config invocation will properly generate multiple config files.
This is necessary for download.scheme with Gerrit 2.9, since it doesn't
allow setting multiple schemes on one line.
