### PR TITLE
Fix escaping issue for single value config items

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,7 +39,7 @@ define gerrit::config(
     exec {
       "config_${name}":
         command => "git config -f ${file} \"${name}\" \'${value}\'",
-        unless  => "git config -f ${file} \"${name}\"|grep -x \'${value}\'",
+        unless  => "test \"$(git config -f ${file} \"${name}\")\" = \'${value}\'",
         path    => $::path,
         require => Exec['install_gerrit'],
     }


### PR DESCRIPTION
Previously this was using grep -x to compare the output of git-config to
what is expected.  This starts to fail on items like the match key for
the commentlink section, since that contains a regex.  This changes it
to do a basic string compare using test.
